### PR TITLE
Fix 'babel-preset-es2015' dependency bug

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
-  "presets": ["es2015-webpack", "stage-0", "react"],
+  "presets": [
+    [
+      "es2015",
+      {"modules": false}
+    ],
+    "stage-0",
+    "react"
+  ],
   "env": {
     "local": {
       "plugins": [["react-transform", {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-es2015-webpack": "^6.4.1",
+    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-es2015-webpack": "^6.4.3",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
@@ -58,7 +58,10 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.13.2",
+    "babel-loader": "^6.2.4",
     "babel-plugin-__coverage__": "^11.0.0",
+    "babel-preset-es2015": "^6.13.2",
     "eslint": "^3.0.1",
     "eslint-loader": "^1.4.1",
     "expect": "^1.20.2",


### PR DESCRIPTION
Encountered bug during installation & setup of sample app.

Fix: 
- In package.json, update "babel-preset-es2015" to 6.13.2 & "babel-preset-es2015-webpack" to 6.4.3
-  Change .babelrc to specify modules: false option, as recommended by [babel-preset-es2015-webpack project](https://github.com/gajus/babel-preset-es2015-webpack/issues/14).
