### PR TITLE
Fixed whitespace in travis.yml to pass linter. Fixes #38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-- "3.5"
-
+    - "3.5"
 sudo: false
 cache:
     directories:
@@ -29,4 +28,4 @@ notifications:
         secure: hMHHY0B/DUPsXnrHkgtbV526fqq2E8ZBYf6jODe6JbFrBKHy/8bFsSf2ET6w3He1VNiUJB1i4WLB4YQarjIWLMzd0zD7nXbtkm4tSYWX3fFd9GZ/HNn9U+c7Ks4Z6KKQ5nyIpBxSxNoJ7cT+AOq/p4uBwHZtvsGsOkEbLzkqdkdkvZl7tKWJ9F47yHu+Kn+uhjmsQa6ZIz8Xjy3Tof12fmnVUaCamtKwM5Tq4s/6p8RNNHpPYUUUUojjMH/2A47s3n3Kc1IkV+EAo+MAIO/dZec39NqFe9Pmm02AWdhEZF9tPHjBhApdAuSalgep1RjckfRSQs7uSc+Tsq0E0/qsfOcZG2WjFdS3ajfE20qyeKH1nYKTs8EAt0LXeGJ2ZvIVTujrKDRy7YgEfPgewkuNkopoj8KVkXUqOd5t4esGFB+Xr2EXUGRCx/XJLlcsNJNUQxBeQcZVxeL9xwwFofKFSYhIcvwfdHgPqfkY6vqvxyTLDsEndZHmxTu7OiZZWr384b9l1Beot0xipmUMVqUnDwS6PTiIbhc/e616NzLpSvLSXYBlnpvDDK+voqZuul1YsFUTMRkj7cmnWdj2COusj1RurlmBJnZjpEWEnWBVpGDmaKu5i8hqi7/ai41eGEiJfC6T4QUKVSMCP5eQ0H7HA+AbIKO1oMvFjq4VxnXd+0I=
 branches:
   only:
-- master
+    - master


### PR DESCRIPTION
After submitting PR to fix babel-webpack dependencies https://github.com/SexualHealthInnovations/callisto-sample-project/pull/40, the travis build failed- I found a couple whitespace issues with a linter and have fixed them in this commit.